### PR TITLE
Use $GLOBALS['user'] instead of global $user

### DIFF
--- a/services_auth_apikeys.module
+++ b/services_auth_apikeys.module
@@ -77,8 +77,7 @@ function services_auth_apikeys_access($account) {
     return TRUE;
   }
   else {
-    global $user;
-    return $user->uid == $account->uid && user_access('services manage own authentication api keys');
+    return $GLOBALS['user']->uid == $account->uid && user_access('services manage own authentication api keys');
   }
 }
 


### PR DESCRIPTION
It's better to use `$GLOBALS['user']` than:

```
global $user;
$user->uid == $account->uid
```
